### PR TITLE
Fix undefined Player

### DIFF
--- a/src/NametagModule.lua
+++ b/src/NametagModule.lua
@@ -144,7 +144,7 @@ module.changeTag = function(tag, objectName, properties)
 			utils.modifyFromProperties(tag:FindFirstChild(objectName), properties)
 		end
 	else
-		error("The function 'getTag' experienced an error. No changes were made to "..player.Name.."'s tag.")
+		error("The function 'getTag' experienced an error. No changes were made to "..tag.Name)
 	end
 end
 


### PR DESCRIPTION
Not the cleanest, can use string.split to get the players name if you wish.
https://github.com/AwesomePossum212/nametag-plus/issues/17